### PR TITLE
issue1：game starting on two player join

### DIFF
--- a/src/main/java/ubc/cosc322/COSC322Test.java
+++ b/src/main/java/ubc/cosc322/COSC322Test.java
@@ -74,6 +74,7 @@ public class COSC322Test extends GamePlayer{
 	@Override
 		public void onLogin() {
 		userName = gameClient.getUserName();
+		System.out.println("Login success. User=" + userName);
 		if(gamegui != null) {
 			gamegui.setRoomInformation(gameClient.getRoomList());
 		}
@@ -92,11 +93,16 @@ public class COSC322Test extends GamePlayer{
 		if (messageType.equals(GameMessage.GAME_ACTION_START)) {
             String blackPlayer = (String) msgDetails.get(AmazonsGameMessage.PLAYER_BLACK);
             String whitePlayer = (String) msgDetails.get(AmazonsGameMessage.PLAYER_WHITE);
-            System.out.println("Game started. Black=" + blackPlayer + ", White=" + whitePlayer + ", Me=" + userName);
+            System.out.println("\n\nGame started.");
+            System.out.println("Room users at start: Black=" + blackPlayer + ", White=" + whitePlayer);
+            System.out.println("Current login user: " + userName+"\n\n");
             ArrayList<Integer> gameState = (ArrayList<Integer>) msgDetails.get(AmazonsGameMessage.GAME_STATE);
             if (gameState != null && this.getGameGUI() != null) {
                 this.getGameGUI().setGameState(gameState);
             }
+		}
+		if (messageType.equals(GameMessage.GAME_STATE_PLAYER_LOST)) {
+			
 		}
 		if (messageType.equals(GameMessage.GAME_ACTION_MOVE)){
 			this.getGameGUI().updateGameState(msgDetails);

--- a/src/main/java/ubc/cosc322/COSC322Test.java
+++ b/src/main/java/ubc/cosc322/COSC322Test.java
@@ -21,33 +21,22 @@ import ygraph.ai.smartfox.games.amazons.AmazonsGameMessage;
  *
  */
 public class COSC322Test extends GamePlayer{
-    private static final String DEFAULT_ROOM = "Okanagan Lake";
 
     private GameClient gameClient = null; 
     private BaseGameGUI gamegui = null;
 	
     private String userName = "cosc322";
     private String passwd = "cosc322";
-    private String autoJoinRoom = null;
+ 	private ArrayList<Integer> gameBoard;
 	
     /**
      * The main method
      * @param args for name and passwd (current, any string would work)
      */
     public static void main(String[] args) {				 
-        String userName = (args.length > 0 && !args[0].trim().isEmpty())
-            ? args[0].trim()
-            : "cosc322_" + System.currentTimeMillis() % 100000;
-        String passwd = (args.length > 1 && !args[1].trim().isEmpty())
-            ? args[1].trim()
-            : "cosc322";
-        String roomToJoin = (args.length > 2 && !args[2].trim().isEmpty())
-            ? args[2].trim()
-            : DEFAULT_ROOM;
-
-        System.out.println("Starting player: user=" + userName + ", room=" + roomToJoin);
-
-    	COSC322Test player = new COSC322Test(userName, passwd, roomToJoin);
+    	String userName = (args.length > 0 && args[0] != null && !args[0].trim().isEmpty()) ? args[0] : "cosc322";
+    	String passwd = (args.length > 1 && args[1] != null && !args[1].trim().isEmpty()) ? args[1] : "cosc322";
+    	COSC322Test player = new COSC322Test(userName, passwd);
 
     	if(player.getGameGUI() == null) {
     		player.Go();
@@ -68,31 +57,26 @@ public class COSC322Test extends GamePlayer{
       * @param passwd
      */
     public COSC322Test(String userName, String passwd) {
-        this(userName, passwd, null);
-    }
-
-    public COSC322Test(String userName, String passwd, String autoJoinRoom) {
-        this.userName = userName;
-        this.passwd = passwd;
-        this.autoJoinRoom = autoJoinRoom;
+    	this.userName = userName;
+    	this.passwd = passwd;
 
     	//To make a GUI-based player, create an instance of BaseGameGUI
     	//and implement the method getGameGUI() accordingly
-        this.gamegui = new BaseGameGUI(this);
+		this.gameBoard=new ArrayList<>();
+		for(int i = 0; i<1000; i++){
+			this.gameBoard.add(0);
+		}
+    	this.gamegui = new BaseGameGUI(this);
     }
  
 
 
-    @Override
+	@Override
 		public void onLogin() {
 		userName = gameClient.getUserName();
 		if(gamegui != null) {
 			gamegui.setRoomInformation(gameClient.getRoomList());
 		}
-
-        if (autoJoinRoom != null && !autoJoinRoom.isEmpty()) {
-            gameClient.joinRoom(autoJoinRoom);
-        }
 	}
 
     @Override
@@ -102,12 +86,10 @@ public class COSC322Test extends GamePlayer{
 	
     	//For a detailed description of the message types and format, 
     	//see the method GamePlayer.handleGameMessage() in the game-client-api document.
-		if (GameMessage.GAME_STATE_BOARD.equals(messageType)){
-            ArrayList<Integer> gameState = (ArrayList<Integer>) msgDetails.get(AmazonsGameMessage.GAME_STATE);
-            if (this.getGameGUI() != null) {
-			    this.getGameGUI().setGameState(gameState);
-            }
-		} else if (GameMessage.GAME_ACTION_START.equals(messageType)) {
+		if (messageType.equals(GameMessage.GAME_STATE_BOARD)){
+			this.getGameGUI().setGameState((ArrayList<Integer>) msgDetails.get(AmazonsGameMessage.GAME_STATE));
+		}
+		if (messageType.equals(GameMessage.GAME_ACTION_START)) {
             String blackPlayer = (String) msgDetails.get(AmazonsGameMessage.PLAYER_BLACK);
             String whitePlayer = (String) msgDetails.get(AmazonsGameMessage.PLAYER_WHITE);
             System.out.println("Game started. Black=" + blackPlayer + ", White=" + whitePlayer + ", Me=" + userName);
@@ -115,10 +97,9 @@ public class COSC322Test extends GamePlayer{
             if (gameState != null && this.getGameGUI() != null) {
                 this.getGameGUI().setGameState(gameState);
             }
-        } else if (GameMessage.GAME_ACTION_MOVE.equals(messageType)){
-            if (this.getGameGUI() != null) {
-			    this.getGameGUI().updateGameState(msgDetails);
-            }
+		}
+		if (messageType.equals(GameMessage.GAME_ACTION_MOVE)){
+			this.getGameGUI().updateGameState(msgDetails);
 		}
     	return true;
     }

--- a/src/main/java/ubc/cosc322/COSC322Test.java
+++ b/src/main/java/ubc/cosc322/COSC322Test.java
@@ -34,7 +34,9 @@ public class COSC322Test extends GamePlayer{
      * @param args for name and passwd (current, any string would work)
      */
     public static void main(String[] args) {				 
-    	String userName = (args.length > 0 && args[0] != null && !args[0].trim().isEmpty()) ? args[0] : "cosc322";
+    	String userName = (args.length > 0 && args[0] != null && !args[0].trim().isEmpty()) 
+    			? args[0] 
+    			: "cosc322_" + (System.currentTimeMillis() % 100000);
     	String passwd = (args.length > 1 && args[1] != null && !args[1].trim().isEmpty()) ? args[1] : "cosc322";
     	COSC322Test player = new COSC322Test(userName, passwd);
 
@@ -68,8 +70,6 @@ public class COSC322Test extends GamePlayer{
 		}
     	this.gamegui = new BaseGameGUI(this);
     }
- 
-
 
 	@Override
 		public void onLogin() {

--- a/src/main/java/ubc/cosc322/COSC322Test.java
+++ b/src/main/java/ubc/cosc322/COSC322Test.java
@@ -21,20 +21,33 @@ import ygraph.ai.smartfox.games.amazons.AmazonsGameMessage;
  *
  */
 public class COSC322Test extends GamePlayer{
+    private static final String DEFAULT_ROOM = "Okanagan Lake";
 
     private GameClient gameClient = null; 
     private BaseGameGUI gamegui = null;
 	
     private String userName = "cosc322";
     private String passwd = "cosc322";
- 	private ArrayList<Integer> gameBoard;
+    private String autoJoinRoom = null;
 	
     /**
      * The main method
      * @param args for name and passwd (current, any string would work)
      */
     public static void main(String[] args) {				 
-    	COSC322Test player = new COSC322Test("args[2]", "args[1]");
+        String userName = (args.length > 0 && !args[0].trim().isEmpty())
+            ? args[0].trim()
+            : "cosc322_" + System.currentTimeMillis() % 100000;
+        String passwd = (args.length > 1 && !args[1].trim().isEmpty())
+            ? args[1].trim()
+            : "cosc322";
+        String roomToJoin = (args.length > 2 && !args[2].trim().isEmpty())
+            ? args[2].trim()
+            : DEFAULT_ROOM;
+
+        System.out.println("Starting player: user=" + userName + ", room=" + roomToJoin);
+
+    	COSC322Test player = new COSC322Test(userName, passwd, roomToJoin);
 
     	if(player.getGameGUI() == null) {
     		player.Go();
@@ -55,16 +68,17 @@ public class COSC322Test extends GamePlayer{
       * @param passwd
      */
     public COSC322Test(String userName, String passwd) {
-    	this.userName = userName;
-    	this.passwd = passwd;
-    	
+        this(userName, passwd, null);
+    }
+
+    public COSC322Test(String userName, String passwd, String autoJoinRoom) {
+        this.userName = userName;
+        this.passwd = passwd;
+        this.autoJoinRoom = autoJoinRoom;
+
     	//To make a GUI-based player, create an instance of BaseGameGUI
     	//and implement the method getGameGUI() accordingly
-		this.gameBoard=new ArrayList<>();
-		for(int i = 0; i<1000; i++){
-			this.gameBoard.add(0);
-		}
-    	this.gamegui = new BaseGameGUI(this);
+        this.gamegui = new BaseGameGUI(this);
     }
  
 
@@ -75,6 +89,10 @@ public class COSC322Test extends GamePlayer{
 		if(gamegui != null) {
 			gamegui.setRoomInformation(gameClient.getRoomList());
 		}
+
+        if (autoJoinRoom != null && !autoJoinRoom.isEmpty()) {
+            gameClient.joinRoom(autoJoinRoom);
+        }
 	}
 
     @Override
@@ -84,13 +102,24 @@ public class COSC322Test extends GamePlayer{
 	
     	//For a detailed description of the message types and format, 
     	//see the method GamePlayer.handleGameMessage() in the game-client-api document.
-		if (messageType.equals(GameMessage.GAME_STATE_BOARD)){
-			this.getGameGUI().setGameState((ArrayList<Integer>) msgDetails.get(AmazonsGameMessage.GAME_STATE));
+		if (GameMessage.GAME_STATE_BOARD.equals(messageType)){
+            ArrayList<Integer> gameState = (ArrayList<Integer>) msgDetails.get(AmazonsGameMessage.GAME_STATE);
+            if (this.getGameGUI() != null) {
+			    this.getGameGUI().setGameState(gameState);
+            }
+		} else if (GameMessage.GAME_ACTION_START.equals(messageType)) {
+            String blackPlayer = (String) msgDetails.get(AmazonsGameMessage.PLAYER_BLACK);
+            String whitePlayer = (String) msgDetails.get(AmazonsGameMessage.PLAYER_WHITE);
+            System.out.println("Game started. Black=" + blackPlayer + ", White=" + whitePlayer + ", Me=" + userName);
+            ArrayList<Integer> gameState = (ArrayList<Integer>) msgDetails.get(AmazonsGameMessage.GAME_STATE);
+            if (gameState != null && this.getGameGUI() != null) {
+                this.getGameGUI().setGameState(gameState);
+            }
+        } else if (GameMessage.GAME_ACTION_MOVE.equals(messageType)){
+            if (this.getGameGUI() != null) {
+			    this.getGameGUI().updateGameState(msgDetails);
+            }
 		}
-		if (messageType.equals(GameMessage.GAME_ACTION_MOVE)){
-			this.getGameGUI().updateGameState(msgDetails);
-		}
-		System.out.println();
     	return true;
     }
     


### PR DESCRIPTION
## PR Summary

This PR introduces a minimal, incremental update to `COSC322Test` to improve multiplayer startup behavior and runtime visibility while keeping the original project structure intact.

### What changed

1. Fixed startup credential handling in `main(...)`
- Replaced hardcoded argument literals with actual CLI argument parsing.
- Added a fallback unique username when no username is provided, to avoid duplicate-login conflicts when launching multiple client instances locally.

2. Added login visibility in console
- On successful login (`onLogin()`), the client now prints the effective logged-in username.

3. Added game-start visibility in console
- On `GAME_ACTION_START`, the client now logs:
  - game start status,
  - black/white player usernames in the room,
  - current local login username.
 
### How to start a game in locally:
1. Connect to UBC web by WIFI or VPN
2. Run two clients on you computer
3. Enter the same room in two clients.